### PR TITLE
Initial files for committee clean-up (`ncopenpass-committee-clean`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+ENV_NAME := $(shell cat environment.yml | grep '^name:' | awk '{print $$2}')
+SHELL := /bin/bash
+
+
+.PHONY: data-pull env env-rm env-rmk
+
+data-pull:
+	rm -rf "s3-data" && wget -i csv-data-files.txt -P s3-data
+
+env:
+	conda env create -f environment.yml || conda env update -f environment.yml
+
+env-rm:
+	conda remove --name $(ENV_NAME) --all -y
+
+env-rmk: env-rm env

--- a/csv-data-files.txt
+++ b/csv-data-files.txt
@@ -1,0 +1,2 @@
+https://nc-campaign-finance-storage.s3.amazonaws.com/sboe-raw-files/candidate_list/candidate_list_2010_to_2020.csv
+https://nc-campaign-finance-storage.s3.amazonaws.com/database-csv-files/committees_export_20210410.csv

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: ncopenpass-campaignfinance-datapipeline
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - cytoolz
+  - pandas

--- a/manual_override.csv
+++ b/manual_override.csv
@@ -1,0 +1,2 @@
+committee_name,manual_entity
+BUTTERBALL PAC INC,BUTTERBALL INC

--- a/ncopenpass-committee-clean.py
+++ b/ncopenpass-committee-clean.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+from pathlib import Path
+from pprint import pprint as pp
+import cytoolz.curried as cc
+import pandas as pd
+import re
+import numpy as np
+
+
+pd.set_option('display.max_rows', 100)
+pd.set_option('display.min_rows', 30)
+pd.set_option('display.max_columns', 500)
+pd.set_option('display.width', 10000)
+
+
+
+data_files = cc.pipe(
+    Path('s3-data').rglob('*.csv')
+    , cc.map(lambda p: (p.stem, pd.read_csv(p)))
+    , dict
+)
+
+
+committee_names_df = (
+    data_files['committees_export_20210410']['committee_name'].to_frame('committee_name')
+    .assign(
+        committee_name_clean=lambda df: (
+            df.committee_name
+            .str.replace(' {2,}', ' ')
+            .str.replace('RE-? ?ELECT', 'ELECT')
+            .str.strip())
+        , committee_entity=pd.NA)
+)
+
+
+
+regex_dict = {
+    'committee_elect_for'        : '(?:COMM(?:ITTEE)? TO ?ELECT (.*)) ?(?: FOR (?:.*))?'
+    , 'committee_elect'          : '(?:COMM(?:ITTEE)? TO ?ELECT (.*))'
+    , 'comm_suffix'              : '(.*) COMM$'
+    , 'comm_to_elect_suffix'     : '^(.*) COMM TO ELECT'
+    , 'comm_in_support_prefix'   : 'COMM IN SUPPORT OF (.*)'
+    , 'vote_for'                 : '^VOTE (.*) FOR (?:.*)'
+    , 'vote'                     : '^VOTE (.*)'
+    , 'citizens_for_x'           : 'CITIZENS FOR (.*)'
+    , 'x_for_x'                  : '^(.*) FOR (?:.*)'
+    , 'x_committee'              : '(.*) COMMITTEE$'
+    , 'committee_to_elect_2word' : '^(?:(?:JUDGE|SHERIFF) ?)(.*) COMM(?:ITTEE)? TO ELECT'
+    , 'friends_of_x'             : 'FRIENDS OF (.*)'
+    , 'elect'                    : 'ELECT (.*)'
+    , 'campaign_suffix'          : '^(.*) CAMPAIGN'
+    , 'keep'                     : 'KEEP (?:JUDGE|SHERIFF)? ?(.*)'
+    , '4'                        : '(.*) 4 (?:.*)'
+    , 'nc_house'                 : '(.*) NC ?HOUSE'
+    , 'citizens_support'         : 'CITIZENS IN SUPPORT OF(?: JUDGE)? (.*)'
+    , 'pac_suffix'               : '^(.*) PAC$'
+    , 'year_suffix'              : '(.*) (?:20)?[0-9]{2}$'
+}
+
+
+
+
+for regex_name, regex_pat in regex_dict.items():
+    committee_names_df[regex_name] = committee_names_df['committee_name_clean'].str.extract(re.compile(regex_pat), expand=False)
+
+
+committee_names_df['committee_entity'] = (
+    committee_names_df.loc[:, regex_dict.keys()].bfill(axis='columns').iloc[:, 0]
+    .str.replace('^(ELECT )?(JUDGE|SHERIFF) ', '')
+    .str.replace('( SHERIFF|JUDGE)$', '')
+    .str.strip()
+)
+
+
+
+manual_override_path = Path('manual_override.csv')
+if manual_override_path.exists():
+    manual_override_df = pd.read_csv(manual_override_path).set_index('committee_name')
+
+    committee_names_df = (
+        committee_names_df.merge(
+            manual_override_df
+            , how='left'
+            , on='committee_name'
+            , suffixes=(None, None))
+        .assign(committee_entity=lambda df: df.committee_entity.mask(pd.isnull, df.manual_entity))
+        .drop(columns=['manual_entity'])
+    )
+
+
+# committee_names_df.iloc[:, :3].to_clipboard(index=False)


### PR DESCRIPTION
Created an initial script and supporting files for doing the committee/candidate linking.

Main script for doing the cleanup is:
-`ncopenpass-committee-clean.py`

Setup for running script would be to do the following:
- `make env`
- `make data-pull`
- run script (`ncopenpass-committee-clean.py`) in REPL and iterate as necessary

Right now the workflow is just to evaluate in a REPL and possibly dump out to clipboard and into e.g. LibreOffice Calc for inspection, but no IO is happening yet. Script assumes committee data is present in the `s3-data` directory (which it should be if `make data-pull` has been run), manual editing is done by changing this `manual_override.csv` file in order to have it update at the last stage of the process.

Supporting files for setup/running are:
- Makefile: recipes for related tasks (downloading data via wget, creating/deleting conda environment, etc.)
- csv-data-files.txt: list of current data files pulled by wget recipe in Makefile
- environment.yml: environment YAML file
- manual_override.csv: CSV file containing entries to manually fix names, must use  the original comittee name in order for the last step of join and update to work correctly; currently just contains 1 entry for BUTTERBALL PAC from initial testing